### PR TITLE
Fix slug validation for making new pages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ django-nyt==1.1.3
 bleach==3.1.0
 markdown==3.1.1
 pillow==6.2.0
+regex==2020.5.14

--- a/src/wiki/plugins/metadata/forms.py
+++ b/src/wiki/plugins/metadata/forms.py
@@ -106,9 +106,9 @@ class ArticleMetadataForm(forms.ModelForm):
 UNICODE_LETTERS_MARKS_HYPHEN_APPOS is [-_\'], all Unicode Letters, Nonspacing Marks, and Spacing Marks
 """
 
-UNICODE_LETTERS_MARKS_HYPHEN_APPOS = r'^[-_\'\p{Letter}\p{Mn}\p{Mc}]+$'
+UNICODE_LETTERS_MARKS_HYPHEN_APPOS = r'^[-_\'\p{L}\p{Mn}\p{Mc}]+$'
 
-slug_mod_unicode_re = _lazy_re_compile(r'^[-\'\w]+\Z')
+slug_mod_unicode_re = regex.compile(r'^[-_\'\p{Letter}\p{Mn}\p{Mc}]+\Z')
 validate_unicode_slug_mod = RegexValidator(
     slug_mod_unicode_re,
     _("Enter a valid 'slug' consisting of Unicode letters, numbers, underscores, hyphens, or apostrophes. Rule of thumb: spell the word as it would appear in a Wiktionary URL (which for some languages means omitting certain diacritics)."),

--- a/src/wiki/plugins/metadata/forms.py
+++ b/src/wiki/plugins/metadata/forms.py
@@ -17,6 +17,7 @@ from wiki.models import ArticleRevision
 import wiki.forms
 from wiki.conf import settings
 import copy, sys
+import regex
 
 '''
 class HorizontalRadioSelect(forms.RadioSelect):
@@ -102,82 +103,15 @@ class ArticleMetadataForm(forms.ModelForm):
 
 # From http://forums.mozillazine.org/viewtopic.php?f=25&t=834075
 """
-UNICODE_LETTERS_HYPHEN_APPOS Represents:
--_\'A-Za-zªµºÀ-ÖØ-öø-ˁˆ-ˑˠ-ˤˬˮͰ-ʹͶ-ͷͺ-ͽΆΈ-ΊΌΎ-ΡΣ-ϵϷ-ҁҊ-ԣԱ-Ֆՙա-ևא-תװ-ײء-يٮ-ٯٱ-ۓەۥ-ۦۮ-ۯۺ-ۼۿܐܒ-ܯݍ-ޥޱߊ-ߪߴ-ߵߺऄ-हऽ
-ॐक़-ॡॱ-ॲॻ-ॿঅ-ঌএ-ঐও-নপ-রলশ-হঽৎড়-ঢ়য়-ৡৰ-ৱਅ-ਊਏ-ਐਓ-ਨਪ-ਰਲ-ਲ਼ਵ-ਸ਼ਸ-ਹਖ਼-ੜਫ਼ੲ-ੴઅ-ઍએ-ઑઓ-નપ-રલ-ળવ-હઽૐૠ-ૡଅ-ଌ
-ଏ-ଐଓ-ନପ-ରଲ-ଳଵ-ହଽଡ଼-ଢ଼ୟ-ୡୱஃஅ-ஊஎ-ஐஒ-கங-சஜஞ-டண-தந-பம-ஹௐఅ-ఌఎ-ఐఒ-నప-ళవ-హఽౘ-ౙౠ-ౡಅ-ಌಎ-ಐ
-ಒ-ನಪ-ಳವ-ಹಽೞೠ-ೡഅ-ഌഎ-ഐഒ-നപ-ഹഽൠ-ൡൺ-ൿඅ-ඖක-නඳ-රලව-ෆก-ะา-ำเ-ๆກ-ຂຄງ-ຈຊຍດ-ທນ-ຟມ-ຣລວສ-ຫອ-ະາ-ຳຽເ-ໄໆ
-ໜ-ໝༀཀ-ཇཉ-ཬྈ-ྋက-ဪဿၐ-ၕၚ-ၝၡၥ-ၦၮ-ၰၵ-ႁႎႠ-Ⴥა-ჺჼᄀ-ᅙᅟ-ᆢᆨ-ᇹሀ-ቈቊ-ቍቐ-ቖቘቚ-ቝበ-ኈኊ-ኍነ-ኰኲ-ኵኸ-ኾዀዂ-ዅወ-ዖዘ-ጐጒ-ጕ
-ጘ-ፚᎀ-ᎏᎠ-Ᏼᐁ-ᙬᙯ-ᙶᚁ-ᚚᚠ-ᛪᛮ-ᛰᜀ-ᜌᜎ-ᜑᜠ-ᜱᝀ-ᝑᝠ-ᝬᝮ-ᝰក-ឳៗៜᠠ-ᡷᢀ-ᢨᢪᤀ-ᤜᥐ-ᥭᥰ-ᥴᦀ-ᦩᧁ-ᧇᨀ-ᨖᬅ-ᬳᭅ-ᭋᮃ-ᮠᮮ-ᮯᰀ-ᰣᱍ-ᱏᱚ-ᱽᴀ-ᶿḀ-ἕἘ-Ἕἠ-ὅ
-Ὀ-Ὅὐ-ὗὙὛὝὟ-ώᾀ-ᾴᾶ-ᾼιῂ-ῄῆ-ῌῐ-ΐῖ-Ίῠ-Ῥῲ-ῴῶ-ῼⁱⁿₐ-ₔℂℇℊ-ℓℕℙ-ℝℤΩℨK-ℭℯ-ℹℼ-ℿⅅ-ⅉⅎⅠ-ↈⰀ-Ⱞⰰ-ⱞⱠ-Ɐⱱ-ⱽⲀ-ⳤⴀ-ⴥⴰ-ⵥⵯⶀ-ⶖⶠ-ⶦⶨ-ⶮⶰ-ⶶ
-ⶸ-ⶾⷀ-ⷆⷈ-ⷎⷐ-ⷖⷘ-ⷞⸯ々-〇〡-〩〱-〵〸-〼ぁ-ゖゝ-ゟァ-ヺー-ヿㄅ-ㄭㄱ-ㆎㆠ-ㆷㇰ-ㇿ㐀䶵一鿃ꀀ-ꒌꔀ-ꘌꘐ-ꘟꘪ-ꘫꙀ-ꙟꙢ-ꙮꙿ-ꚗꜗ-ꜟꜢ-ꞈꞋ-ꞌꟻ-ꠁ
-ꠃ-ꠅꠇ-ꠊꠌ-ꠢꡀ-ꡳꢂ-ꢳꤊ-ꤥꤰ-ꥆꨀ-ꨨꩀ-ꩂꩄ-ꩋ가힣豈-鶴侮-頻並-龎ﬀ-ﬆﬓ-ﬗיִײַ-ﬨשׁ-זּטּ-לּמּנּ-סּףּ-פּצּ-ﮱﯓ-ﴽﵐ-ﶏﶒ-ﷇﷰ-ﷻﹰ-ﹴﹶ-ﻼＡ-Ｚａ-ｚｦ-ﾾￂ-ￇￊ-ￏￒ-ￗￚ-ￜ
+UNICODE_LETTERS_MARKS_HYPHEN_APPOS is [-_\'], all Unicode Letters, Nonspacing Marks, and Spacing Marks
 """
 
-UNICODE_LETTERS_HYPHEN_APPOS = (
-    r'^[-_\'\u0041-\u005A\u0061-\u007A\u00AA\u00B5\u00BA\u00C0-\u00D6\u00D8-\u00F6'
-    r'\u00F8-\u02C1\u02C6-\u02D1\u02E0-\u02E4\u02EC\u02EE\u0370-\u0374'
-    r'\u0376-\u0377\u037A-\u037D\u0386\u0388-\u038A\u038C\u038E-\u03A1'
-    r'\u03A3-\u03F5\u03F7-\u0481\u048A-\u0523\u0531-\u0556\u0559\u0561-\u0587'
-    r'\u05D0-\u05EA\u05F0-\u05F2\u0621-\u064A\u066E-\u066F\u0671-\u06D3\u06D5'
-    r'\u06E5-\u06E6\u06EE-\u06EF\u06FA-\u06FC\u06FF\u0710\u0712-\u072F'
-    r'\u074D-\u07A5\u07B1\u07CA-\u07EA\u07F4-\u07F5\u07FA\u0904-\u0939\u093D'
-    r'\u0950\u0958-\u0961\u0971-\u0972\u097B-\u097F\u0985-\u098C\u098F-\u0990'
-    r'\u0993-\u09A8\u09AA-\u09B0\u09B2\u09B6-\u09B9\u09BD\u09CE\u09DC-\u09DD'
-    r'\u09DF-\u09E1\u09F0-\u09F1\u0A05-\u0A0A\u0A0F-\u0A10\u0A13-\u0A28'
-    r'\u0A2A-\u0A30\u0A32-\u0A33\u0A35-\u0A36\u0A38-\u0A39\u0A59-\u0A5C\u0A5E'
-    r'\u0A72-\u0A74\u0A85-\u0A8D\u0A8F-\u0A91\u0A93-\u0AA8\u0AAA-\u0AB0'
-    r'\u0AB2-\u0AB3\u0AB5-\u0AB9\u0ABD\u0AD0\u0AE0-\u0AE1\u0B05-\u0B0C'
-    r'\u0B0F-\u0B10\u0B13-\u0B28\u0B2A-\u0B30\u0B32-\u0B33\u0B35-\u0B39\u0B3D'
-    r'\u0B5C-\u0B5D\u0B5F-\u0B61\u0B71\u0B83\u0B85-\u0B8A\u0B8E-\u0B90'
-    r'\u0B92-\u0B95\u0B99-\u0B9A\u0B9C\u0B9E-\u0B9F\u0BA3-\u0BA4\u0BA8-\u0BAA'
-    r'\u0BAE-\u0BB9\u0BD0\u0C05-\u0C0C\u0C0E-\u0C10\u0C12-\u0C28\u0C2A-\u0C33'
-    r'\u0C35-\u0C39\u0C3D\u0C58-\u0C59\u0C60-\u0C61\u0C85-\u0C8C\u0C8E-\u0C90'
-    r'\u0C92-\u0CA8\u0CAA-\u0CB3\u0CB5-\u0CB9\u0CBD\u0CDE\u0CE0-\u0CE1'
-    r'\u0D05-\u0D0C\u0D0E-\u0D10\u0D12-\u0D28\u0D2A-\u0D39\u0D3D\u0D60-\u0D61'
-    r'\u0D7A-\u0D7F\u0D85-\u0D96\u0D9A-\u0DB1\u0DB3-\u0DBB\u0DBD\u0DC0-\u0DC6'
-    r'\u0E01-\u0E30\u0E32-\u0E33\u0E40-\u0E46\u0E81-\u0E82\u0E84\u0E87-\u0E88'
-    r'\u0E8A\u0E8D\u0E94-\u0E97\u0E99-\u0E9F\u0EA1-\u0EA3\u0EA5\u0EA7'
-    r'\u0EAA-\u0EAB\u0EAD-\u0EB0\u0EB2-\u0EB3\u0EBD\u0EC0-\u0EC4\u0EC6'
-    r'\u0EDC-\u0EDD\u0F00\u0F40-\u0F47\u0F49-\u0F6C\u0F88-\u0F8B\u1000-\u102A'
-    r'\u103F\u1050-\u1055\u105A-\u105D\u1061\u1065-\u1066\u106E-\u1070'
-    r'\u1075-\u1081\u108E\u10A0-\u10C5\u10D0-\u10FA\u10FC\u1100-\u1159'
-    r'\u115F-\u11A2\u11A8-\u11F9\u1200-\u1248\u124A-\u124D\u1250-\u1256\u1258'
-    r'\u125A-\u125D\u1260-\u1288\u128A-\u128D\u1290-\u12B0\u12B2-\u12B5'
-    r'\u12B8-\u12BE\u12C0\u12C2-\u12C5\u12C8-\u12D6\u12D8-\u1310\u1312-\u1315'
-    r'\u1318-\u135A\u1380-\u138F\u13A0-\u13F4\u1401-\u166C\u166F-\u1676'
-    r'\u1681-\u169A\u16A0-\u16EA\u16EE-\u16F0\u1700-\u170C\u170E-\u1711'
-    r'\u1720-\u1731\u1740-\u1751\u1760-\u176C\u176E-\u1770\u1780-\u17B3\u17D7'
-    r'\u17DC\u1820-\u1877\u1880-\u18A8\u18AA\u1900-\u191C\u1950-\u196D'
-    r'\u1970-\u1974\u1980-\u19A9\u19C1-\u19C7\u1A00-\u1A16\u1B05-\u1B33'
-    r'\u1B45-\u1B4B\u1B83-\u1BA0\u1BAE-\u1BAF\u1C00-\u1C23\u1C4D-\u1C4F'
-    r'\u1C5A-\u1C7D\u1D00-\u1DBF\u1E00-\u1F15\u1F18-\u1F1D\u1F20-\u1F45'
-    r'\u1F48-\u1F4D\u1F50-\u1F57\u1F59\u1F5B\u1F5D\u1F5F-\u1F7D\u1F80-\u1FB4'
-    r'\u1FB6-\u1FBC\u1FBE\u1FC2-\u1FC4\u1FC6-\u1FCC\u1FD0-\u1FD3\u1FD6-\u1FDB'
-    r'\u1FE0-\u1FEC\u1FF2-\u1FF4\u1FF6-\u1FFC\u2071\u207F\u2090-\u2094\u2102'
-    r'\u2107\u210A-\u2113\u2115\u2119-\u211D\u2124\u2126\u2128\u212A-\u212D'
-    r'\u212F-\u2139\u213C-\u213F\u2145-\u2149\u214E\u2160-\u2188\u2C00-\u2C2E'
-    r'\u2C30-\u2C5E\u2C60-\u2C6F\u2C71-\u2C7D\u2C80-\u2CE4\u2D00-\u2D25'
-    r'\u2D30-\u2D65\u2D6F\u2D80-\u2D96\u2DA0-\u2DA6\u2DA8-\u2DAE\u2DB0-\u2DB6'
-    r'\u2DB8-\u2DBE\u2DC0-\u2DC6\u2DC8-\u2DCE\u2DD0-\u2DD6\u2DD8-\u2DDE\u2E2F'
-    r'\u3005-\u3007\u3021-\u3029\u3031-\u3035\u3038-\u303C\u3041-\u3096'
-    r'\u309D-\u309F\u30A1-\u30FA\u30FC-\u30FF\u3105-\u312D\u3131-\u318E'
-    r'\u31A0-\u31B7\u31F0-\u31FF\u3400\u4DB5\u4E00\u9FC3\uA000-\uA48C'
-    r'\uA500-\uA60C\uA610-\uA61F\uA62A-\uA62B\uA640-\uA65F\uA662-\uA66E'
-    r'\uA67F-\uA697\uA717-\uA71F\uA722-\uA788\uA78B-\uA78C\uA7FB-\uA801'
-    r'\uA803-\uA805\uA807-\uA80A\uA80C-\uA822\uA840-\uA873\uA882-\uA8B3'
-    r'\uA90A-\uA925\uA930-\uA946\uAA00-\uAA28\uAA40-\uAA42\uAA44-\uAA4B\uAC00'
-    r'\uD7A3\uF900-\uFA2D\uFA30-\uFA6A\uFA70-\uFAD9\uFB00-\uFB06\uFB13-\uFB17'
-    r'\uFB1D\uFB1F-\uFB28\uFB2A-\uFB36\uFB38-\uFB3C\uFB3E\uFB40-\uFB41'
-    r'\uFB43-\uFB44\uFB46-\uFBB1\uFBD3-\uFD3D\uFD50-\uFD8F\uFD92-\uFDC7'
-    r'\uFDF0-\uFDFB\uFE70-\uFE74\uFE76-\uFEFC\uFF21-\uFF3A\uFF41-\uFF5A'
-    r'\uFF66-\uFFBE\uFFC2-\uFFC7\uFFCA-\uFFCF\uFFD2-\uFFD7\uFFDA-\uFFDC]+$'
-    )
+UNICODE_LETTERS_MARKS_HYPHEN_APPOS = r'^[-_\'\p{Letter}\p{Mn}\p{Mc}]+$'
 
 slug_mod_unicode_re = _lazy_re_compile(r'^[-\'\w]+\Z')
 validate_unicode_slug_mod = RegexValidator(
     slug_mod_unicode_re,
-    _("Enter a valid 'slug' consisting of Unicode letters, numbers, underscores, hyphens, or apostrophes."),
+    _("Enter a valid 'slug' consisting of Unicode letters, numbers, underscores, hyphens, or apostrophes. Rule of thumb: spell the word as it would appear in a Wiktionary URL (which for some languages means omitting certain diacritics)."),
     'invalid'
 )
 validate_slug_numbers = RegexValidator(
@@ -346,7 +280,7 @@ class AdpositionForm(ArticleMetadataForm):
         self.fields['slug'].widget = wiki.forms.TextInputPrepend(
             prepend='/' + self.article.urlpath_set.all()[0].path,
             attrs={
-                'pattern': UNICODE_LETTERS_HYPHEN_APPOS,
+                'pattern': UNICODE_LETTERS_MARKS_HYPHEN_APPOS,
                 'title': 'Letters, hyphens, underscores, apostrophes'
             }
         )

--- a/src/wiki/plugins/metadata/static/wiki/js/modurlify.js
+++ b/src/wiki/plugins/metadata/static/wiki/js/modurlify.js
@@ -173,10 +173,10 @@ namespace and hence we couldn't change its behavior from outside.
             // Keep Unicode letters including both lowercase and uppercase
             // characters, whitespace, and dash; remove other characters.
             if (allowApostrophe) {
-              s = XRegExp.replace(s, XRegExp('[^-_\'\\p{L}\\p{N}\\s]', 'g'), '');
+              s = XRegExp.replace(s, XRegExp('[^-_\'\\p{L}\\p{N}\\p{Mn}\\p{Mc}\\s]', 'g'), '');
             }
             else {
-              s = XRegExp.replace(s, XRegExp('[^-_\\p{L}\\p{N}\\s]', 'g'), '');
+              s = XRegExp.replace(s, XRegExp('[^-_\\p{L}\\p{N}\\p{Mn}\\p{Mc}\\s]', 'g'), '');
             }
         } else {
             s = s.replace(/[^-\w\s]/g, '');  // remove unneeded chars

--- a/src/wiki/static/wiki/js/urlify.js
+++ b/src/wiki/static/wiki/js/urlify.js
@@ -172,7 +172,7 @@ namespace and hence we couldn't change its behavior from outside.
         if (allowUnicode) {
             // Keep Unicode letters and numbers including both lowercase and uppercase
             // characters, whitespace, underscore, and hyphen; remove other characters.
-            s = XRegExp.replace(s, XRegExp('[^-_\\p{L}\\p{N}\\s]', 'g'), '');
+            s = XRegExp.replace(s, XRegExp('[^-_\\p{L}\\p{N}\\p{Mn}\\p{Mc}\\s]', 'g'), '');
         } else {
             s = s.replace(/[^-\w\s]/g, '');  // remove unneeded chars
         }

--- a/xposition/xp/settings/local.py
+++ b/xposition/xp/settings/local.py
@@ -3,5 +3,5 @@
 
 # git update-index --assume-unchanged testproject/testproject/settings/local.py
 
-from .dev import *  # noqa @UnusedWildImport
-# from .base import *
+#from .dev import *  # noqa @UnusedWildImport
+from .base import *

--- a/xposition/xp/settings/local.py
+++ b/xposition/xp/settings/local.py
@@ -3,5 +3,5 @@
 
 # git update-index --assume-unchanged testproject/testproject/settings/local.py
 
-#from .dev import *  # noqa @UnusedWildImport
-from .base import *
+from .dev import *  # noqa @UnusedWildImport
+# from .base import *


### PR DESCRIPTION
I haven't been able to use Devanagari in new page slugs because certain combining marks (included as `Mn` and `Mc` in Unicode) which are actually vowel marking diacritics are not allowed by the validation regexes. These vowel markers, unlike in Hebrew and Arabic, are not optional in the word. This change should allow them in Devanagari as well as in other abugida scripts.