### PR TITLE
Error handling for macros

### DIFF
--- a/src/wiki/plugins/macros/mdx/macro.py
+++ b/src/wiki/plugins/macros/mdx/macro.py
@@ -185,7 +185,8 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
                     link_elt.text = short
                     return link_elt
         except:
-            return '<span style="color:red;">'+'Macro Error: please see example usage'+'</span>'
+            span = '<span style="color:red">' + 'Macro Error: please see example usage' + '</span>'
+            return etree.fromstring(span)
         return link(short, '/' + prep, cl if cl else 'adposition')
 
     # meta data
@@ -235,7 +236,8 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
                     link_elt.text = text
                     return link_elt
         except:
-            return '<span style="color:red;">'+'Macro Error: please see example usage'+'</span>'
+            span = '<span style="color:red">' + 'Macro Error: please see example usage' + '</span>'
+            return etree.fromstring(span)
         return link(text, '/' + prep, cl if cl else 'adposition')
 
     # meta data
@@ -280,7 +282,8 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
                 link_elt = link(display, '/' + args[0].replace('`', '%60'), cls)
                 return show_deprecation(supersense, link_elt)
         except:
-            return '<span style="color:red;">'+'Macro Error: please see example usage'+'</span>'
+            span = '<span style="color:red">' + 'Macro Error: please see example usage' + '</span>'
+            return etree.fromstring(span)
 
     # meta data
     ss.meta = dict(
@@ -323,7 +326,8 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
                 display = f'{ref_title}#{id}' if not ref_title == my_title else f'#{id}'
                 a.text = display
         except:
-            return '<span style="color:red;">'+'Macro Error: please see example usage'+'</span>'
+            span = '<span style="color:red">' + 'Macro Error: please see example usage' + '</span>'
+            return etree.fromstring(span)
         return a
 
     # meta data
@@ -357,7 +361,8 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
                 exlabel_a.set("href", "#" + id)
                 exlabel_a.text = id
         except:
-            return '<span style="color:red;">'+'Macro Error: please see example usage'+'</span>'
+            span = '<span style="color:red">' + 'Macro Error: please see example usage' + '</span>'
+            return etree.fromstring(span)
         return span
 
     # meta data
@@ -424,7 +429,8 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
             a_ex.set("class", "exlabel")
             a_ex.text = id
         except:
-            return 'Error: see example usage'
+            span = '<span style="color:red">'+'Macro Error: please see example usage'+'</span>'
+            return etree.fromstring(span)
         return span
 
     # meta data

--- a/src/wiki/plugins/macros/mdx/macro.py
+++ b/src/wiki/plugins/macros/mdx/macro.py
@@ -185,7 +185,7 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
                     link_elt.text = short
                     return link_elt
         except:
-            span = '<span style="color:red">' + 'Macro Error: please see example usage' + '</span>'
+            span = '<span class="error">' + 'Macro Error: please see example usage' + '</span>'
             return etree.fromstring(span)
         return link(short, '/' + prep, cl if cl else 'adposition')
 
@@ -236,7 +236,7 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
                     link_elt.text = text
                     return link_elt
         except:
-            span = '<span style="color:red">' + 'Macro Error: please see example usage' + '</span>'
+            span = '<span class="error">' + 'Macro Error: please see example usage' + '</span>'
             return etree.fromstring(span)
         return link(text, '/' + prep, cl if cl else 'adposition')
 
@@ -282,7 +282,7 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
                 link_elt = link(display, '/' + args[0].replace('`', '%60'), cls)
                 return show_deprecation(supersense, link_elt)
         except:
-            span = '<span style="color:red">' + 'Macro Error: please see example usage' + '</span>'
+            span = '<span class="error">' + 'Macro Error: please see example usage' + '</span>'
             return etree.fromstring(span)
 
     # meta data
@@ -326,7 +326,7 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
                 display = f'{ref_title}#{id}' if not ref_title == my_title else f'#{id}'
                 a.text = display
         except:
-            span = '<span style="color:red">' + 'Macro Error: please see example usage' + '</span>'
+            span = '<span class="error">' + 'Macro Error: please see example usage' + '</span>'
             return etree.fromstring(span)
         return a
 
@@ -361,7 +361,7 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
                 exlabel_a.set("href", "#" + id)
                 exlabel_a.text = id
         except:
-            span = '<span style="color:red">' + 'Macro Error: please see example usage' + '</span>'
+            span = '<span class="error">' + 'Macro Error: please see example usage' + '</span>'
             return etree.fromstring(span)
         return span
 
@@ -429,7 +429,7 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
             a_ex.set("class", "exlabel")
             a_ex.text = id
         except:
-            span = '<span style="color:red">'+'Macro Error: please see example usage'+'</span>'
+            span = '<span class="error">'+'Macro Error: please see example usage'+'</span>'
             return etree.fromstring(span)
         return span
 

--- a/src/wiki/plugins/macros/mdx/macro.py
+++ b/src/wiki/plugins/macros/mdx/macro.py
@@ -185,7 +185,7 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
                     link_elt.text = short
                     return link_elt
         except:
-            return 'Error'
+            return '<span style="color:red;">'+'Macro Error: please see example usage'+'</span>'
         return link(short, '/' + prep, cl if cl else 'adposition')
 
     # meta data
@@ -235,7 +235,7 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
                     link_elt.text = text
                     return link_elt
         except:
-            return 'Error'
+            return '<span style="color:red;">'+'Macro Error: please see example usage'+'</span>'
         return link(text, '/' + prep, cl if cl else 'adposition')
 
     # meta data
@@ -280,7 +280,7 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
                 link_elt = link(display, '/' + args[0].replace('`', '%60'), cls)
                 return show_deprecation(supersense, link_elt)
         except:
-            return 'Error'
+            return '<span style="color:red;">'+'Macro Error: please see example usage'+'</span>'
 
     # meta data
     ss.meta = dict(
@@ -323,7 +323,7 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
                 display = f'{ref_title}#{id}' if not ref_title == my_title else f'#{id}'
                 a.text = display
         except:
-            return 'Error'
+            return '<span style="color:red;">'+'Macro Error: please see example usage'+'</span>'
         return a
 
     # meta data
@@ -357,7 +357,7 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
                 exlabel_a.set("href", "#" + id)
                 exlabel_a.text = id
         except:
-            return 'Error'
+            return '<span style="color:red;">'+'Macro Error: please see example usage'+'</span>'
         return span
 
     # meta data
@@ -424,7 +424,7 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
             a_ex.set("class", "exlabel")
             a_ex.text = id
         except:
-            return 'Error'
+            return 'Error: see example usage'
         return span
 
     # meta data

--- a/src/wiki/plugins/macros/mdx/macro.py
+++ b/src/wiki/plugins/macros/mdx/macro.py
@@ -147,6 +147,9 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
         example_code='[[WikiLink]]',
         args={})
 
+    def errormsg(self):
+        return etree.fromstring('<span class="error">' + 'Macro Error: please see example usage' + '</span>')
+
     def p(self, **kwargs):
         try:
             args = argize_kwargs(kwargs)
@@ -184,10 +187,10 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
                     link_elt = etree.fromstring(f'<a class="{cl}" href="{href}"></a>')
                     link_elt.text = short
                     return link_elt
+            return link(short, '/' + prep, cl if cl else 'adposition')
         except:
-            span = '<span class="error">' + 'Macro Error: please see example usage' + '</span>'
-            return etree.fromstring(span)
-        return link(short, '/' + prep, cl if cl else 'adposition')
+            return self.errormsg()
+
 
     # meta data
     p.meta = dict(
@@ -235,10 +238,10 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
                     link_elt = etree.fromstring(f'<a class="{cl}" href="{href}"></a>')
                     link_elt.text = text
                     return link_elt
+            return link(text, '/' + prep, cl if cl else 'adposition')
         except:
-            span = '<span class="error">' + 'Macro Error: please see example usage' + '</span>'
-            return etree.fromstring(span)
-        return link(text, '/' + prep, cl if cl else 'adposition')
+            return self.errormsg()
+
 
     # meta data
     pspecial.meta = dict(
@@ -282,8 +285,7 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
                 link_elt = link(display, '/' + args[0].replace('`', '%60'), cls)
                 return show_deprecation(supersense, link_elt)
         except:
-            span = '<span class="error">' + 'Macro Error: please see example usage' + '</span>'
-            return etree.fromstring(span)
+            return self.errormsg()
 
     # meta data
     ss.meta = dict(
@@ -325,10 +327,10 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
             else:
                 display = f'{ref_title}#{id}' if not ref_title == my_title else f'#{id}'
                 a.text = display
+            return a
         except:
-            span = '<span class="error">' + 'Macro Error: please see example usage' + '</span>'
-            return etree.fromstring(span)
-        return a
+            return self.errormsg()
+
 
     # meta data
     exref.meta = dict(
@@ -360,10 +362,9 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
                 exlabel_a.set("class", "exlabel")
                 exlabel_a.set("href", "#" + id)
                 exlabel_a.text = id
+            return span
         except:
-            span = '<span class="error">' + 'Macro Error: please see example usage' + '</span>'
-            return etree.fromstring(span)
-        return span
+            return self.errormsg()
 
     # meta data
     ex.meta = dict(
@@ -428,10 +429,9 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
             a_ex.set("href", "#" + id)
             a_ex.set("class", "exlabel")
             a_ex.text = id
+            return span
         except:
-            span = '<span class="error">'+'Macro Error: please see example usage'+'</span>'
-            return etree.fromstring(span)
-        return span
+            return self.errormsg()
 
     # meta data
     gex.meta = dict(

--- a/src/wiki/plugins/macros/mdx/macro.py
+++ b/src/wiki/plugins/macros/mdx/macro.py
@@ -27,6 +27,7 @@ KWARG_RE = re.compile(
 # invocations.
 POSITIONAL_MACROS = ["p", "pspecial", "ss", "exref", "ex", "gex"]
 
+
 class MacroExtension(markdown.Extension):
     """ Macro plugin markdown extension for django-wiki. """
 
@@ -118,6 +119,7 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
                 'depth': int(depth) + 1,
             })
         return self.markdown.htmlStash.store(html)
+
     article_list.meta = dict(
         short_description=_('Article list'),
         help_text=_('Insert a list of articles in this level.'),
@@ -127,6 +129,7 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
 
     def toc(self):
         return "[TOC]"
+
     toc.meta = dict(
         short_description=_('Table of contents'),
         help_text=_('Insert a table of contents matching the headings.'),
@@ -136,6 +139,7 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
 
     def wikilink(self):
         return ""
+
     wikilink.meta = dict(
         short_description=_('WikiLinks'),
         help_text=_(
@@ -143,44 +147,47 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
         example_code='[[WikiLink]]',
         args={})
 
-
     def p(self, **kwargs):
-        args = argize_kwargs(kwargs)
-        cl = None
-        prep = args[0]
-        short = prep.split('/')[-1]
-        p = models.Adposition.normalize_adp(cls=models.Adposition,
-                                            adp=short,
-                                            language_name=prep.split('/')[-2])
-        if p:
-            prep = prep.replace(short, p)
-        if len(args) >= 3:
-            cl = args[2]
-        if len(args) > 1 and not '-' == args[1]:
-            construal = args[1]
-            if '`' in construal:
-                return link(short, '/' + prep + '/' + construal, cl if cl else 'usage')
-            elif "'" in construal or '?' in construal:
-                return link(short.replace('--','&#x219d;'), '/' + prep + '/' + construal, cl if cl else 'usage')
-            else:
-                cl = cl if cl else 'usage'
-                if '--' in construal:   # 2 supersenses specified: role, function
-                    ss1, ss2 = get_supersenses_for_construal(construal)
-                    supersenses = (ss1, ss2)
+        try:
+            args = argize_kwargs(kwargs)
+            cl = None
+            prep = args[0]
+            short = prep.split('/')[-1]
+            p = models.Adposition.normalize_adp(cls=models.Adposition,
+                                                adp=short,
+                                                language_name=prep.split('/')[-2])
+            if p:
+                prep = prep.replace(short, p)
+            if len(args) >= 3:
+                cl = args[2]
+            if len(args) > 1 and not '-' == args[1]:
+                construal = args[1]
+                if '`' in construal:
+                    return link(short, '/' + prep + '/' + construal, cl if cl else 'usage')
+                elif "'" in construal or '?' in construal:
+                    return link(short.replace('--', '&#x219d;'), '/' + prep + '/' + construal, cl if cl else 'usage')
                 else:
-                    ss = get_supersense(construal)
-                    if ss is None:  # special (backtick) labels are represented as construals with no role or function
-                        supersenses = ()
-                    else:   # single supersense specified, so it will be both role and function in the construal
-                        supersenses = (ss,)
-                        construal = construal + '--' + construal
-                cl += " usage-deprecated" if any(ss_is_deprecated(ss) for ss in supersenses) else ""
-                short = short.replace('--','&#x219d;')
-                href = '/' + prep + '/' + construal
-                link_elt = etree.fromstring(f'<a class="{cl}" href="{href}"></a>')
-                link_elt.text = short
-                return link_elt
+                    cl = cl if cl else 'usage'
+                    if '--' in construal:  # 2 supersenses specified: role, function
+                        ss1, ss2 = get_supersenses_for_construal(construal)
+                        supersenses = (ss1, ss2)
+                    else:
+                        ss = get_supersense(construal)
+                        if ss is None:  # special (backtick) labels are represented as construals with no role or function
+                            supersenses = ()
+                        else:  # single supersense specified, so it will be both role and function in the construal
+                            supersenses = (ss,)
+                            construal = construal + '--' + construal
+                    cl += " usage-deprecated" if any(ss_is_deprecated(ss) for ss in supersenses) else ""
+                    short = short.replace('--', '&#x219d;')
+                    href = '/' + prep + '/' + construal
+                    link_elt = etree.fromstring(f'<a class="{cl}" href="{href}"></a>')
+                    link_elt.text = short
+                    return link_elt
+        except:
+            return 'Error'
         return link(short, '/' + prep, cl if cl else 'adposition')
+
     # meta data
     p.meta = dict(
         short_description=_('Link to Adposition, Usage'),
@@ -190,43 +197,47 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
     )
 
     def pspecial(self, **kwargs):
-        args = argize_kwargs(kwargs)
-        cl = None
-        text = args[0]
-        prep = args[1]
-        p = models.Adposition.normalize_adp(cls=models.Adposition,
-                                            adp=prep.split('/')[-1],
-                                            language_name=prep.split('/')[-2])
-        if p:
-            prep = prep.replace(prep.split('/')[-1], p)
-        if len(args) >= 4:
-            cl = args[3]
+        try:
+            args = argize_kwargs(kwargs)
+            cl = None
+            text = args[0]
+            prep = args[1]
+            p = models.Adposition.normalize_adp(cls=models.Adposition,
+                                                adp=prep.split('/')[-1],
+                                                language_name=prep.split('/')[-2])
+            if p:
+                prep = prep.replace(prep.split('/')[-1], p)
+            if len(args) >= 4:
+                cl = args[3]
 
-        if len(args) > 2 and not '-' == args[2]:
-            construal = args[2]
-            if '`' in construal:
-                return link(text, '/' + prep + '/' + construal, cl if cl else 'usage')
-            elif "'" in construal or '?' in construal:
-                return link(text.replace('--', '&#x219d;'), '/' + prep + '/' + construal, cl if cl else 'usage')
-            else:
-                cl = cl if cl else 'usage'
-                if '--' in construal:   # 2 supersenses specified: role, function
-                    ss1, ss2 = get_supersenses_for_construal(construal)
-                    supersenses = (ss1, ss2)
+            if len(args) > 2 and not '-' == args[2]:
+                construal = args[2]
+                if '`' in construal:
+                    return link(text, '/' + prep + '/' + construal, cl if cl else 'usage')
+                elif "'" in construal or '?' in construal:
+                    return link(text.replace('--', '&#x219d;'), '/' + prep + '/' + construal, cl if cl else 'usage')
                 else:
-                    ss = get_supersense(construal)
-                    if ss is None:  # special (backtick) labels are represented as construals with no role or function
-                        supersenses = ()
-                    else:   # single supersense specified, so it will be both role and function in the construal
-                        supersenses = (ss,)
-                        construal = construal + '--' + construal
-                cl += " usage-deprecated" if any(ss_is_deprecated(ss) for ss in supersenses) else ""
-                text = text.replace('--','&#x219d;')
-                href = '/' + prep + '/' + construal
-                link_elt = etree.fromstring(f'<a class="{cl}" href="{href}"></a>')
-                link_elt.text = text
-                return link_elt
+                    cl = cl if cl else 'usage'
+                    if '--' in construal:  # 2 supersenses specified: role, function
+                        ss1, ss2 = get_supersenses_for_construal(construal)
+                        supersenses = (ss1, ss2)
+                    else:
+                        ss = get_supersense(construal)
+                        if ss is None:  # special (backtick) labels are represented as construals with no role or function
+                            supersenses = ()
+                        else:  # single supersense specified, so it will be both role and function in the construal
+                            supersenses = (ss,)
+                            construal = construal + '--' + construal
+                    cl += " usage-deprecated" if any(ss_is_deprecated(ss) for ss in supersenses) else ""
+                    text = text.replace('--', '&#x219d;')
+                    href = '/' + prep + '/' + construal
+                    link_elt = etree.fromstring(f'<a class="{cl}" href="{href}"></a>')
+                    link_elt.text = text
+                    return link_elt
+        except:
+            return 'Error'
         return link(text, '/' + prep, cl if cl else 'adposition')
+
     # meta data
     pspecial.meta = dict(
         short_description=_('Link to Adposition, Usage'),
@@ -235,39 +246,42 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
         args={'prep': _('Name of adposition'), 'special': _('Text to display'), 'construal': _('Name of construal'), 'class': _('optional class')}
     )
 
-
     def ss(self, **kwargs):
-        args = argize_kwargs(kwargs)
+        try:
+            args = argize_kwargs(kwargs)
 
-        cl = None
-        if len(args) >= 2:
-            cl = args[1]
+            cl = None
+            if len(args) >= 2:
+                cl = args[1]
 
-        self_reference = args[0] == escape_patterns_in_string(self.markdown.article.current_revision.title)
+            self_reference = args[0] == escape_patterns_in_string(self.markdown.article.current_revision.title)
 
-        if '--' in args[0]:
-            ss1, ss2 = get_supersenses_for_construal(args[0])
-            cls = cl or 'construal'
-            if self_reference:
-                cls += " this-construal"
-                cspan = construal_span(ss1, ss2, cls)
-                return cspan
+            if '--' in args[0]:
+                ss1, ss2 = get_supersenses_for_construal(args[0])
+                cls = cl or 'construal'
+                if self_reference:
+                    cls += " this-construal"
+                    cspan = construal_span(ss1, ss2, cls)
+                    return cspan
+                else:
+                    clink = construal_link(ss1, ss2, '/' + args[0], cl if cl else 'construal')
+                    return clink
             else:
-                clink = construal_link(ss1, ss2, '/' + args[0], cl if cl else 'construal')
-                return clink
-        else:
-            supersense = get_supersense(args[0])
-            display = args[0].replace('`',r'\`')
-            cls = cl or 'supersense'
-            if args[0] in ['??','`d','`i','`c','`$']:
-                cls = cl or 'misc-label'
-            if self_reference:
-                span = etree.Element("span")
-                span.set("class", cls + " this-supersense")
-                span.text = display
-                return show_deprecation(supersense, span)
-            link_elt = link(display, '/' + args[0].replace('`','%60'), cls)
-            return show_deprecation(supersense, link_elt)
+                supersense = get_supersense(args[0])
+                display = args[0].replace('`', r'\`')
+                cls = cl or 'supersense'
+                if args[0] in ['??', '`d', '`i', '`c', '`$']:
+                    cls = cl or 'misc-label'
+                if self_reference:
+                    span = etree.Element("span")
+                    span.set("class", cls + " this-supersense")
+                    span.text = display
+                    return show_deprecation(supersense, span)
+                link_elt = link(display, '/' + args[0].replace('`', '%60'), cls)
+                return show_deprecation(supersense, link_elt)
+        except:
+            return 'Error'
+
     # meta data
     ss.meta = dict(
         short_description=_('Link to Supersense or Construal'),
@@ -277,36 +291,39 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
     )
 
     def exref(self, **kwargs):
-        args = argize_kwargs(kwargs)
-        id = args[0]
-        page = args[1]
-        my_title = escape_patterns_in_string(self.markdown.article.current_revision.title)
-        ref_title = page
-        ref_slug = page
-        # try to find article
-        x = Article.objects.filter(current_revision__title=ref_title)
-        # check for article with matching title
-        if x:
-            ref_slug = str(x[0].urlpath_set.all()[0])
-            if ref_slug[0]=='/':
-                ref_slug = ref_slug[1:]
-            if ref_slug[-1]=='/':
-                ref_slug = ref_slug[:-1]
+        try:
+            args = argize_kwargs(kwargs)
+            id = args[0]
+            page = args[1]
+            my_title = escape_patterns_in_string(self.markdown.article.current_revision.title)
+            ref_title = page
+            ref_slug = page
+            # try to find article
+            x = Article.objects.filter(current_revision__title=ref_title)
+            # check for article with matching title
+            if x:
+                ref_slug = str(x[0].urlpath_set.all()[0])
+                if ref_slug[0] == '/':
+                    ref_slug = ref_slug[1:]
+                if ref_slug[-1] == '/':
+                    ref_slug = ref_slug[:-1]
 
-        supersense = get_supersense(args[1])
+            supersense = get_supersense(args[1])
 
-        a = etree.Element("a")
-        a.set("href", '/' + ref_slug + '/#' + id)
-        a.set("class", 'exref')
-        if supersense is not None and ref_title != my_title:
-            ss_span = etree.SubElement(a, 'span')
-            ss_span.text = ref_title
-            ss_span = show_deprecation(supersense, ss_span, normal_class="", deprecated_class="exref-deprecated")
-            rest_span = etree.SubElement(a, 'span')
-            rest_span.text = f'#{id}'
-        else:
-            display = f'{ref_title}#{id}' if not ref_title == my_title else f'#{id}'
-            a.text = display
+            a = etree.Element("a")
+            a.set("href", '/' + ref_slug + '/#' + id)
+            a.set("class", 'exref')
+            if supersense is not None and ref_title != my_title:
+                ss_span = etree.SubElement(a, 'span')
+                ss_span.text = ref_title
+                ss_span = show_deprecation(supersense, ss_span, normal_class="", deprecated_class="exref-deprecated")
+                rest_span = etree.SubElement(a, 'span')
+                rest_span.text = f'#{id}'
+            else:
+                display = f'{ref_title}#{id}' if not ref_title == my_title else f'#{id}'
+                a.text = display
+        except:
+            return 'Error'
         return a
 
     # meta data
@@ -318,28 +335,31 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
     )
 
     def ex(self, **kwargs):
-        args = argize_kwargs(kwargs)
-        id = args[0]
-        sent = args[1]
-        label = args[2] if len(args) > 2 else None
+        try:
+            args = argize_kwargs(kwargs)
+            id = args[0]
+            sent = args[1]
+            label = args[2] if len(args) > 2 else None
 
-        span = etree.Element("span")
-        span.set("id", id)
-        span.set("class", "example")
-        sent_span = etree.SubElement(span, "span")
-        sent_span.text = sent + " "
+            span = etree.Element("span")
+            span.set("id", id)
+            span.set("class", "example")
+            sent_span = etree.SubElement(span, "span")
+            sent_span.text = sent + " "
 
-        if label:
-            exlabel_span = etree.SubElement(span, "span")
-            exlabel_span.set("class", "exlabel")
-            exlabel_span.text = label
-        else:
-            exlabel_a = etree.SubElement(span, "a")
-            exlabel_a.set("class", "exlabel")
-            exlabel_a.set("href", "#" + id)
-            exlabel_a.text = id
-
+            if label:
+                exlabel_span = etree.SubElement(span, "span")
+                exlabel_span.set("class", "exlabel")
+                exlabel_span.text = label
+            else:
+                exlabel_a = etree.SubElement(span, "a")
+                exlabel_a.set("class", "exlabel")
+                exlabel_a.set("href", "#" + id)
+                exlabel_a.text = id
+        except:
+            return 'Error'
         return span
+
     # meta data
     ex.meta = dict(
         short_description=_('Create an Example'),
@@ -349,60 +369,64 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
     )
 
     GLOSS_RE = re.compile('^\{(?P<tok_gloss>[^}]*?)\}')
+
     def gex(self, **kwargs):
-        args = argize_kwargs(kwargs)
-        id = args[0]
-        sent = args[1]
-        sent_gloss = args[2] if len(args) > 2 else ''
-        columns = []
-        while len(sent)>0:
-            gloss = self.GLOSS_RE.match(sent)
-            if gloss:
-                word_gloss = gloss.group('tok_gloss')
-                sent = sent[len(gloss.group()):]
-                if '||' in word_gloss:
-                    xs = word_gloss.split('||')
-                else:
-                    xs = word_gloss.split()
-                xs = [escape(x) for x in xs]
-                column = etree.Element("div")
-                column.set("class", "gll")
-                for i, x in enumerate(xs):
-                    span_x = etree.SubElement(column, "span")
-                    if i != len(xs) - 1:
-                        etree.SubElement(span_x, "br")
-                    span_x.text = x
-            else:
-                end = sent.index('{') if '{' in sent else len(sent)
-                word_gloss = sent[:end]
-                sent = sent[len(word_gloss):]
-                if word_gloss.strip():
+        try:
+            args = argize_kwargs(kwargs)
+            id = args[0]
+            sent = args[1]
+            sent_gloss = args[2] if len(args) > 2 else ''
+            columns = []
+            while len(sent) > 0:
+                gloss = self.GLOSS_RE.match(sent)
+                if gloss:
+                    word_gloss = gloss.group('tok_gloss')
+                    sent = sent[len(gloss.group()):]
+                    if '||' in word_gloss:
+                        xs = word_gloss.split('||')
+                    else:
+                        xs = word_gloss.split()
+                    xs = [escape(x) for x in xs]
                     column = etree.Element("div")
                     column.set("class", "gll")
-                    column.text = word_gloss.strip()
+                    for i, x in enumerate(xs):
+                        span_x = etree.SubElement(column, "span")
+                        if i != len(xs) - 1:
+                            etree.SubElement(span_x, "br")
+                        span_x.text = x
                 else:
-                    column = etree.Element("span")
-            columns.append(column)
+                    end = sent.index('{') if '{' in sent else len(sent)
+                    word_gloss = sent[:end]
+                    sent = sent[len(word_gloss):]
+                    if word_gloss.strip():
+                        column = etree.Element("div")
+                        column.set("class", "gll")
+                        column.text = word_gloss.strip()
+                    else:
+                        column = etree.Element("span")
+                columns.append(column)
 
-        span = etree.Element("span")
-        span.set("id", id)
-        span.set("class", "example")
-        div = etree.SubElement(span, "div")
-        div.set("class", "interlinear example")
-        p_interlinear = etree.SubElement(div, "p")
-        p_interlinear.set("class", "gloss")
-        for col in columns:
-            p_interlinear.append(col)
-        p_trans = etree.SubElement(div, "p")
-        p_trans.set("class", "translation")
-        span_trans = etree.SubElement(p_trans, "span")
-        span_trans.text = "'" + sent_gloss + "' "
-        a_ex = etree.SubElement(p_trans, "a")
-        a_ex.set("href", "#" + id)
-        a_ex.set("class", "exlabel")
-        a_ex.text = id
-
+            span = etree.Element("span")
+            span.set("id", id)
+            span.set("class", "example")
+            div = etree.SubElement(span, "div")
+            div.set("class", "interlinear example")
+            p_interlinear = etree.SubElement(div, "p")
+            p_interlinear.set("class", "gloss")
+            for col in columns:
+                p_interlinear.append(col)
+            p_trans = etree.SubElement(div, "p")
+            p_trans.set("class", "translation")
+            span_trans = etree.SubElement(p_trans, "span")
+            span_trans.text = "'" + sent_gloss + "' "
+            a_ex = etree.SubElement(p_trans, "a")
+            a_ex.set("href", "#" + id)
+            a_ex.set("class", "exlabel")
+            a_ex.text = id
+        except:
+            return 'Error'
         return span
+
     # meta data
     gex.meta = dict(
         short_description=_('Create a Glossed Example'),
@@ -424,19 +448,23 @@ def link(t, l, clazz):
     a.text = t
     return a
 
+
 def makeExtension(*args, **kwargs):
     """Return an instance of the extension."""
     return MacroExtension(*args, **kwargs)
 
+
 def argize_kwargs(kwargs):
     args = []
     # arg0, arg1, ..., arg10, etc.
-    for arg in sorted(kwargs.keys(), key=lambda x:int(x[3:])):
+    for arg in sorted(kwargs.keys(), key=lambda x: int(x[3:])):
         args.append(kwargs[arg])
     return args
 
+
 def ss_is_deprecated(ss):
     return ss is None or ss.current_revision.metadatarevision.supersenserevision.deprecated
+
 
 def show_deprecation(ss, elt, normal_class="supersense", deprecated_class="supersense-deprecated"):
     # unclear why `entry.deprecated` didn't work..
@@ -444,11 +472,13 @@ def show_deprecation(ss, elt, normal_class="supersense", deprecated_class="super
         elt.set("class", normal_class + " " + deprecated_class)
     return elt
 
+
 def get_supersense(supersense_string):
     try:
         return models.Supersense.objects.get(category__name=supersense_string)
     except models.Supersense.DoesNotExist:
         return None
+
 
 def get_supersenses_for_construal(construal_string):
     try:
@@ -461,6 +491,7 @@ def get_supersenses_for_construal(construal_string):
 
     return ss1, ss2
 
+
 def construal_span(ss1, ss2, cls):
     span1 = '<span' + (' class="supersense-deprecated">' if ss_is_deprecated(ss1) else '>')
     span1 += ss1.current_revision.metadatarevision.name if ss1 else 'INVALIDSS'
@@ -471,6 +502,7 @@ def construal_span(ss1, ss2, cls):
     span = f'<span class="{cls}">{span1}&#x219d;{span2}</span>'
     return etree.fromstring(span)
 
+
 def construal_link(ss1, ss2, href, cls):
     span1 = '<span' + (' class="supersense-deprecated">' if ss_is_deprecated(ss1) else '>')
     span1 += ss1.current_revision.metadatarevision.name if ss1 else 'INVALIDSS'
@@ -480,4 +512,3 @@ def construal_link(ss1, ss2, href, cls):
     span2 += '</span>'
     a = f'<a href="{href}" class="{cls}">{span1}&#x219d;{span2}</a>'
     return etree.fromstring(a)
-

--- a/src/wiki/plugins/metadata/static/wiki/css/metadata.css
+++ b/src/wiki/plugins/metadata/static/wiki/css/metadata.css
@@ -81,6 +81,10 @@ a.usage:hover {
 }
 a.usage > .construal { font-weight: normal; }
 
+.error {
+  color: #f00;
+}
+
 th:empty { display: none; }
 
 u { text-decoration: none; background-color: #eee; }


### PR DESCRIPTION
Macros display "Macro Error: please see example usage" in red when the macro input results in an error. This prevents the page from crashing.