### PR TITLE
add tqdm and pilow>=7.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ sorl-thumbnail==12.6.2
 django-nyt==1.1.5
 bleach==3.3.0
 markdown==3.1.1
-pillow==6.2.2
+pillow>=7.1.0
+tqdm
 regex==2020.5.14
 git+git://github.com/nert-nlp/django-categories.git@master


### PR DESCRIPTION
Tested Pillow == 8.1.0 and added tqdm to requirements.txt, in line with #211 .

Tested the supersense, construals, and a language article, the token annotations grid, and tested editing a page and meta-data and adding a new category. 

This PR has overlap with #213 . Would recommend merging #213 first, followed by this one. #213 freezes pillow to 7.1.0, this one does a '>=7.1.0' instead.